### PR TITLE
Various bug-fixes and improvements to 1.9.2

### DIFF
--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -8930,53 +8930,67 @@ namespace DSPRE {
         }
 
         private void trainerSaveCurrentButton_Click(object sender, EventArgs e) {
-            currentTrainerFile.trp.partyCount = (byte)partyCountUpDown.Value;
-            currentTrainerFile.trp.chooseMoves = trainerMovesCheckBox.Checked;
-            currentTrainerFile.trp.chooseItems = trainerItemsCheckBox.Checked;
-            currentTrainerFile.trp.doubleBattle = trainerDoubleCheckBox.Checked;
+            if(trainerNameTextBox.Text.Length < 8)
+            {
+                currentTrainerFile.trp.partyCount = (byte)partyCountUpDown.Value;
+                currentTrainerFile.trp.chooseMoves = trainerMovesCheckBox.Checked;
+                currentTrainerFile.trp.chooseItems = trainerItemsCheckBox.Checked;
+                currentTrainerFile.trp.doubleBattle = trainerDoubleCheckBox.Checked;
 
-            IList trainerItems = trainerItemsGroupBox.Controls;
-            for (int i = 0; i < trainerItems.Count; i++) {
-                currentTrainerFile.trp.trainerItems[i] = (ushort)(trainerItems[i] as ComboBox).SelectedIndex;
-            }
+                IList trainerItems = trainerItemsGroupBox.Controls;
+                for (int i = 0; i < trainerItems.Count; i++)
+                {
+                    currentTrainerFile.trp.trainerItems[i] = (ushort)(trainerItems[i] as ComboBox).SelectedIndex;
+                }
 
-            IList trainerAI = TrainerAIGroupBox.Controls;
-            for (int i = 0; i < trainerAI.Count; i++) {
-                currentTrainerFile.trp.AI[i] = (trainerAI[i] as CheckBox).Checked;
-            }
+                IList trainerAI = TrainerAIGroupBox.Controls;
+                for (int i = 0; i < trainerAI.Count; i++)
+                {
+                    currentTrainerFile.trp.AI[i] = (trainerAI[i] as CheckBox).Checked;
+                }
 
-            for (int i = 0; i < TrainerFile.POKE_IN_PARTY; i++) {
-                currentTrainerFile.party[i].moves = trainerMovesCheckBox.Checked ? new ushort[4] : null;
-            }
+                for (int i = 0; i < TrainerFile.POKE_IN_PARTY; i++)
+                {
+                    currentTrainerFile.party[i].moves = trainerMovesCheckBox.Checked ? new ushort[4] : null;
+                }
 
-            for (int i = 0; i < partyCountUpDown.Value; i++) {
-                currentTrainerFile.party[i].pokeID = (ushort)partyPokemonComboboxList[i].SelectedIndex;
-                currentTrainerFile.party[i].level = (ushort)partyLevelUpdownList[i].Value;
+                for (int i = 0; i < partyCountUpDown.Value; i++)
+                {
+                    currentTrainerFile.party[i].pokeID = (ushort)partyPokemonComboboxList[i].SelectedIndex;
+                    currentTrainerFile.party[i].level = (ushort)partyLevelUpdownList[i].Value;
 
-                if (trainerMovesCheckBox.Checked) {
-                    IList movesList = partyMovesGroupboxList[i].Controls;
-                    for (int j = 0; j < Party.MOVES_PER_POKE; j++) {
-                        currentTrainerFile.party[i].moves[j] = (ushort)(movesList[j] as ComboBox).SelectedIndex;
+                    if (trainerMovesCheckBox.Checked)
+                    {
+                        IList movesList = partyMovesGroupboxList[i].Controls;
+                        for (int j = 0; j < Party.MOVES_PER_POKE; j++)
+                        {
+                            currentTrainerFile.party[i].moves[j] = (ushort)(movesList[j] as ComboBox).SelectedIndex;
+                        }
                     }
+
+                    if (trainerItemsCheckBox.Checked)
+                    {
+                        currentTrainerFile.party[i].heldItem = (ushort)partyItemsComboboxList[i].SelectedIndex;
+                    }
+
+                    currentTrainerFile.party[i].difficulty = (ushort)partyIVUpdownList[i].Value;
+                    currentTrainerFile.party[i].ballSeals = (ushort)partyBallUpdownList[i].Value;
                 }
 
-                if (trainerItemsCheckBox.Checked) {
-                    currentTrainerFile.party[i].heldItem = (ushort)partyItemsComboboxList[i].SelectedIndex;
-                }
+                /*Write to File*/
+                string indexStr = "\\" + trainerComboBox.SelectedIndex.ToString("D4");
+                File.WriteAllBytes(RomInfo.gameDirs[DirNames.trainerProperties].unpackedDir + indexStr, currentTrainerFile.trp.ToByteArray());
+                File.WriteAllBytes(RomInfo.gameDirs[DirNames.trainerParty].unpackedDir + indexStr, currentTrainerFile.party.ToByteArray());
 
-                currentTrainerFile.party[i].difficulty = (ushort)partyIVUpdownList[i].Value;
-                currentTrainerFile.party[i].ballSeals = (ushort)partyBallUpdownList[i].Value;
+                UpdateCurrentTrainerName(newName: trainerNameTextBox.Text);
+                UpdateCurrentTrainerShownName();
+
+                MessageBox.Show("Trainer saved successfully!", "", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            } else
+            {
+                MessageBox.Show("The length of the trainer name exceeds the maximum allowed by DSPRE currently which is 7 characters.", "Trainer data could not be saved!", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-
-            /*Write to File*/
-            string indexStr = "\\" + trainerComboBox.SelectedIndex.ToString("D4");
-            File.WriteAllBytes(RomInfo.gameDirs[DirNames.trainerProperties].unpackedDir + indexStr, currentTrainerFile.trp.ToByteArray());
-            File.WriteAllBytes(RomInfo.gameDirs[DirNames.trainerParty].unpackedDir + indexStr, currentTrainerFile.party.ToByteArray());
-
-            UpdateCurrentTrainerName(newName: trainerNameTextBox.Text);
-            UpdateCurrentTrainerShownName();
-
-            MessageBox.Show("Trainer saved successfully!", "", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            
         }
 
         private void UpdateCurrentTrainerShownName() {

--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -8777,14 +8777,18 @@ namespace DSPRE {
             int paletteId = 0;
             string iconTablePath;
 
-            int iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - RomInfo.synthOverlayLoadAddress);
-            if (iconPalTableOffsetFromFileStart >= 0) { // if iconPalTableAddress >= RomInfo.synthOverlayLoadAddress
-                //In other words, if the pointer shows the table was moved to the synthetic overlay
-                if (File.Exists(DSUtils.GetOverlayPath(129)))
-                    iconTablePath = DSUtils.GetOverlayPath(129); // HG-engine new overlay for icons
-                else
-                    iconTablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
+            int iconPalTableOffsetFromFileStart;
+            if (File.Exists(DSUtils.GetOverlayPath(129))) {
+                // if overlay 129 exists, read it from there
+                iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - DSUtils.GetOverlayRAMAddress(129));
+                iconTablePath = DSUtils.GetOverlayPath(129);
+            }
+            else if ((int)(RomInfo.monIconPalTableAddress - RomInfo.synthOverlayLoadAddress) >= 0) { 
+                // if there is a synthetic overlay, read it from there
+                iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - RomInfo.synthOverlayLoadAddress);
+                iconTablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
             } else {
+                // default handling
                 iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - DSUtils.ARM9.address);
                 iconTablePath = RomInfo.arm9Path;
             }

--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -5843,12 +5843,12 @@ namespace DSPRE {
             if (normalRadioButton.Checked == true) {
                 owScriptNumericUpDown.Enabled = true;
                 owSpecialGroupBox.Enabled = false;
-
-                currentEvFile.overworlds[overworldsListBox.SelectedIndex].scriptNumber = (ushort)(owScriptNumericUpDown.Value = 0);
+                
                 if (disableHandlers) {
                     return;
                 }
                 currentEvFile.overworlds[overworldsListBox.SelectedIndex].type = 0x0;
+                currentEvFile.overworlds[overworldsListBox.SelectedIndex].scriptNumber = (ushort)(owScriptNumericUpDown.Value = 0);
             } else if (isItemRadioButton.Checked == true) {
                 owScriptNumericUpDown.Enabled = false;
 
@@ -5909,7 +5909,7 @@ namespace DSPRE {
             disableHandlers = true;
 
             selectedEvent = currentEvFile.overworlds[index];
-            Overworld selectedOw = (Overworld)selectedEvent;
+            Overworld selectedOw = (Overworld)selectedEvent;            
             try {
                 /* Sprite index and image controls */
                 owSpriteComboBox.SelectedIndex = Array.IndexOf(RomInfo.overworldTableKeys, selectedOw.overlayTableEntry);

--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -5863,12 +5863,12 @@ namespace DSPRE {
                     owItemComboBox.Enabled = true;
                     itemsSelectorHelpBtn.Enabled = true;
                     owItemLabel.Enabled = true;
-
-                    currentEvFile.overworlds[overworldsListBox.SelectedIndex].scriptNumber = (ushort)(owScriptNumericUpDown.Value = 7000 + owItemComboBox.SelectedIndex);
+                    
                     if (disableHandlers) {
                         return;
                     }
                     currentEvFile.overworlds[overworldsListBox.SelectedIndex].type = 0x3;
+                    currentEvFile.overworlds[overworldsListBox.SelectedIndex].scriptNumber = (ushort)(owScriptNumericUpDown.Value = 7000 + owItemComboBox.SelectedIndex);
                 }
             } else { //trainer
                 owScriptNumericUpDown.Enabled = false;

--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -8782,7 +8782,10 @@ namespace DSPRE {
             int iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - RomInfo.synthOverlayLoadAddress);
             if (iconPalTableOffsetFromFileStart >= 0) { // if iconPalTableAddress >= RomInfo.synthOverlayLoadAddress
                 //In other words, if the pointer shows the table was moved to the synthetic overlay
-                iconTablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
+                if (File.Exists(DSUtils.GetOverlayPath(129)))
+                    iconTablePath = DSUtils.GetOverlayPath(129); // HG-engine new overlay for icons
+                else
+                    iconTablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
             } else {
                 iconPalTableOffsetFromFileStart = (int)(RomInfo.monIconPalTableAddress - DSUtils.ARM9.address);
                 iconTablePath = RomInfo.arm9Path;

--- a/DS_Map/Main Window.cs
+++ b/DS_Map/Main Window.cs
@@ -8693,7 +8693,6 @@ namespace DSPRE {
             string[] trNames = RomInfo.GetSimpleTrainerNames();
 
             bool error = currentIndex >= trNames.Length;
-
             currentTrainerFile = new TrainerFile(
                 new TrainerProperties(
                     (ushort)trainerComboBox.SelectedIndex, 
@@ -8702,7 +8701,6 @@ namespace DSPRE {
                 new FileStream(RomInfo.gameDirs[DirNames.trainerParty].unpackedDir + suffix, FileMode.Open),
                 error ? TrainerFile.NAME_NOT_FOUND : trNames[currentIndex]
             );
-
             RefreshTrainerPartyGUI();
             RefreshTrainerPropertiesGUI();
 

--- a/DS_Map/ROMFiles/TextArchive.cs
+++ b/DS_Map/ROMFiles/TextArchive.cs
@@ -88,7 +88,7 @@ namespace DSPRE.ROMFiles {
                                     pokemonText.Append(car.ToString("X4"));
                                     specialCharON = false;
                                 } else if (compressed) {
-                                    #region Compressed String
+                                    #region Compressed String                                    
                                     int shift = 0;
                                     int trans = 0;
                                     string uncomp = "";

--- a/DS_Map/ROMFiles/TrainerFile.cs
+++ b/DS_Map/ROMFiles/TrainerFile.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Windows.Forms;
+using static DSPRE.DSUtils.ARM9;
 
 namespace DSPRE.ROMFiles {
     public class PartyPokemon : RomFile {
@@ -36,6 +37,15 @@ namespace DSPRE.ROMFiles {
             this.heldItem = heldItem;
             this.moves = moves;
         }
+        public PartyPokemon(ushort difficulty, ushort Level, ushort pokeNum, ushort? heldItem = null, ushort[] moves = null)
+        {
+            // Simply adding a new constructor for Diamond and Pearl since they dont have ball seal config
+            pokeID = pokeNum;
+            level = Level;
+            this.difficulty = difficulty;
+            this.heldItem = heldItem;
+            this.moves = moves;
+        }
         public PartyPokemon(ushort difficulty, ushort Level, ushort pokeNum, ushort formNum, ushort ballSealConfig, ushort? heldItem = null, ushort[] moves = null) :
             this(difficulty, Level, pokeNum, ballSealConfig, heldItem, moves) {
 
@@ -57,7 +67,8 @@ namespace DSPRE.ROMFiles {
                         writer.Write(move);
                     }
                 }
-                writer.Write(ballSeals);
+                if(RomInfo.gameFamily == RomInfo.gFamEnum.HGSS || RomInfo.gameFamily == RomInfo.gFamEnum.Plat) 
+                    writer.Write(ballSeals); // Diamond and Pearl apparently dont save ball capsule data in enemy trainer pokedata!!!
             }
             return newData.ToArray();
         }
@@ -224,8 +235,11 @@ namespace DSPRE.ROMFiles {
                                 moves[m] = (ushort)(val == ushort.MaxValue ? 0 : val);
                             }
                         }
+                        if (RomInfo.gameFamily == RomInfo.gFamEnum.HGSS || RomInfo.gameFamily == RomInfo.gFamEnum.Plat)
+                            content[i] = new PartyPokemon(unknown1, level, pokemon, form_no, reader.ReadUInt16(), heldItem, moves); 
+                        else
+                            content[i] = new PartyPokemon(unknown1, level, pokemon, form_no, heldItem, moves); // Diamond and Pearl apparently dont save ball capsule data in enemy trainer pokedata!!!
 
-                        content[i] = new PartyPokemon(unknown1, level, pokemon, form_no, reader.ReadUInt16(), heldItem, moves);
                     }
                     for (int i = endval; i < maxPoke; i++) {
                         content[i] = new PartyPokemon();

--- a/DS_Map/ROMFiles/TrainerFile.cs
+++ b/DS_Map/ROMFiles/TrainerFile.cs
@@ -309,9 +309,6 @@ namespace DSPRE.ROMFiles {
         public string name;
         public TrainerProperties trp;
         public Party party;
-        public int COMPRESSED_MASK = 0x01FF;
-        public int COMPRESSED_EOS = 0x01FF;
-        public ushort CHAR_EOS = 0xFFFF;
         #endregion
 
         #region Constructor
@@ -332,10 +329,7 @@ namespace DSPRE.ROMFiles {
         public override byte[] ToByteArray() {
             MemoryStream newData = new MemoryStream();
             using (BinaryWriter writer = new BinaryWriter(newData)) {
-                ushort[] compName = CompressTrainerName(name);
-                byte[] compressedName = new byte[compName.Length];
-                Array.Copy(compName, 0, compressedName, 0, compName.Length - 1);
-                writer.Write(compressedName);
+                writer.Write(name);
                 byte[] trDat = trp.ToByteArray();
                 writer.Write((byte)trDat.Length);
                 writer.Write(trDat);
@@ -349,73 +343,7 @@ namespace DSPRE.ROMFiles {
 
         public void SaveToFileExplorePath(string suggestedFileName, bool showSuccessMessage = true) {
             SaveToFileExplorePath("Gen IV Trainer File", "trf", suggestedFileName, showSuccessMessage);
-        }
-
-        public int[] Compress(char[] uncompressedString)
-        {
-            int container = 0;
-            int bitshift = 0;
-            int index = 0;
-            int[] newBinaryString = new int[uncompressedString.Length / 2];
-
-            newBinaryString[0] = 0xf100;
-            for (int i = 1; i < newBinaryString.Length; i++)
-            {
-                int c = uncompressedString[index];
-                if ((c >> 9) == 1)
-                    throw new Exception(string.Format("{0:x4} cannot be compressed", c));
-                container |= c << bitshift;
-                bitshift += 9;
-                while (bitshift >= 0xf)
-                {
-                    bitshift -= 0xf;
-                    newBinaryString[index++] = container & 0xffff;
-                    container >>= 0xf;
-                }
-            }
-            container |= 0xffff << bitshift;
-            newBinaryString[index] = container & 0xffff;            
-            return newBinaryString;
-        }
-
-        public ushort[] CompressTrainerName(string src)
-        {
-            ushort[] dstChar = new ushort[src.Length / 2];
-            ushort[] srcChar = new ushort[src.Length];
-            Array.Copy(src.ToCharArray(), 1, srcChar, 0, src.Length - 1);
-            int shift = 0;
-            int charsAdded = 0;
-            ushort curChar = 0;
-
-            while (true)
-            {
-                curChar = dstChar[charsAdded];
-
-                if (curChar == COMPRESSED_EOS)
-                {
-                    break;
-                }
-
-                if (shift != 0)
-                {
-                    srcChar[2] = srcChar[1];
-                    srcChar[1] = srcChar[0];
-                    srcChar[0] = (ushort)((curChar >> (9 - shift)) & COMPRESSED_MASK);
-                }
-
-                shift += 9;
-
-                if (shift >= 15)
-                {
-                    shift -= 15;
-                }
-
-                charsAdded++;
-            }
-
-            dstChar[charsAdded] = CHAR_EOS;
-            return dstChar;
-        }
+        }      
 
         #endregion
 

--- a/DS_Map/RomInfo.cs
+++ b/DS_Map/RomInfo.cs
@@ -531,9 +531,15 @@ namespace DSPRE {
                                 "displayed incorrectly or not displayed at all.", "Decompression error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             return;
                         }
-                        if (ramAddressOfTable >= RomInfo.synthOverlayLoadAddress) { // if the pointer shows the table was moved to the synthetic overlay
-                            OWTableOffset = ramAddressOfTable - RomInfo.synthOverlayLoadAddress;
-                            OWtablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
+                        if (ramAddressOfTable >= RomInfo.synthOverlayLoadAddress) { 
+                            // if the pointer shows the table was moved to the synthetic overlay
+                            if (File.Exists(DSUtils.GetOverlayPath(131))) {
+                                OWTableOffset = ramAddressOfTable - DSUtils.GetOverlayRAMAddress(131);
+                                OWtablePath = DSUtils.GetOverlayPath(131); // HG-Engine new OW overlay
+                            } else {
+                                OWTableOffset = ramAddressOfTable - RomInfo.synthOverlayLoadAddress;
+                                OWtablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
+                            }
                         } else {
                             OWTableOffset = ramAddressOfTable - ov1Address;
                             OWtablePath = ov1Path;

--- a/DS_Map/RomInfo.cs
+++ b/DS_Map/RomInfo.cs
@@ -526,20 +526,21 @@ namespace DSPRE {
 
                     using (DSUtils.EasyReader bReader = new DSUtils.EasyReader(ov1Path, ramAddrOfPointer - ov1Address)) { // read the pointer at the specified ram address and adjust accordingly below
                         uint ramAddressOfTable = bReader.ReadUInt32();
-                        if (ramAddressOfTable >= 0x03000000) {
+                        if ((((UInt32)(ramAddressOfTable) >> 0x18)) != 0x02) {
                             MessageBox.Show("Something went wrong reading the Overworld configuration table.\nOverworld sprites in the Event Editor will be " +
                                 "displayed incorrectly or not displayed at all.", "Decompression error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             return;
                         }
-                        if (ramAddressOfTable >= RomInfo.synthOverlayLoadAddress) { 
+                        if (File.Exists(DSUtils.GetOverlayPath(131))) { 
+                            // if HGE field extension overlay exists
+                            OWTableOffset = ramAddressOfTable - DSUtils.GetOverlayRAMAddress(131);
+                            OWtablePath = DSUtils.GetOverlayPath(131);
+                        }
+                        else if (ramAddressOfTable >= RomInfo.synthOverlayLoadAddress) { 
                             // if the pointer shows the table was moved to the synthetic overlay
-                            if (File.Exists(DSUtils.GetOverlayPath(131))) {
-                                OWTableOffset = ramAddressOfTable - DSUtils.GetOverlayRAMAddress(131);
-                                OWtablePath = DSUtils.GetOverlayPath(131); // HG-Engine new OW overlay
-                            } else {
-                                OWTableOffset = ramAddressOfTable - RomInfo.synthOverlayLoadAddress;
-                                OWtablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
-                            }
+                            OWTableOffset = ramAddressOfTable - RomInfo.synthOverlayLoadAddress;
+                            OWtablePath = gameDirs[DirNames.synthOverlay].unpackedDir + "\\" + ROMToolboxDialog.expandedARMfileID.ToString("D4");
+                            
                         } else {
                             OWTableOffset = ramAddressOfTable - ov1Address;
                             OWtablePath = ov1Path;


### PR DESCRIPTION
# Bugfixes and improvements to version 1.9.2

This PR contains various bugfixes and improvements to 1.9.2 in preparation for 1.9.3 or above

## Bugfixes

### Overworld Bug setting script to 0 when going from Item or Trainer to Normal (NPC)

Setting `scriptNumber` to 0 was being done before checking if it needed to do so via `if (disableHandlers)` making any change from any OWType back to Normal (NPC) resetting script number.

### Overworld Bug setting item to last selected when going from Item to Trainer to Item

Setting `scriptNumber` to dropdown value was being done before checking if it needed to do so via `if (disableHandlers)` making any change from Item to any OWType back to Item resetting script number to first Item.

### Trainer editor for Diamond and Pearl broke if more than one pokemon

The pokemon trainer party data for Diamond and Pearl does not contain the data for ball capsules as opposed to Plat and HGSS so the last readUint16 was causing EndOfFile on pokemon parties for trainers.

### Event editor scrolling or changing did not load map.

I have added a dictionary loaded at start of rom load that keeps a dict of event to headers and this allows inside event editor to know what map, matrix, areaData. etc... since we simply load the new header on change and get the data.

## Improvements

### HG-Engine compatibility

Included changes from BluRosie's fork so as to enable DSPRE to work with hg-engine ROMs. Change essentially is just a change of an OWTable overlay and an Icons one

### Mikelan Patch compatibility

Included changes from BluRosie's fork so as to enable DSPRE to work with mikelan patch ROMs. Change essentially is just a change of an OWTable overlay and an Icons one
